### PR TITLE
Remove dependency on ArgumentCheck

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -14,8 +14,7 @@ Imports:
     MCMCglmm,
     plyr,
     rjags,
-    stats,
-    ArgumentCheck
+    stats
 Author: Claudio Quezada-Romegialli, Andrew L Jackson, Chris Harrod
 URL: https://github.com/clquezada/tRophicPosition
 BugReports: https://groups.google.com/d/forum/trophicposition-support

--- a/R/jagsBayesianModel.R
+++ b/R/jagsBayesianModel.R
@@ -46,19 +46,17 @@ jagsBayesianModel <- function (model = NULL, ... ) {
   #   if(!grepl("dbeta", argument[[1]])) flag_dbeta <- TRUE
   # }
   #
-  # Check <- ArgumentCheck::newArgCheck()
+  # Check <- checkmate::makeAssertCollection()
   #
   # if (flag_dnorm | flag_dunif | flag_dbeta)
-  #   ArgumentCheck::addWarning(
-  #     msg = "It seems that you are not using dnorm(mean, sd),  dunif(min, max)
+  #   Check$push(
+  #     "It seems that you are not using dnorm(mean, sd),  dunif(min, max)
   # or dbeta(a, b) as priors, or they are not correctly written. Please check
-  # the arguments",
-  #     argcheck = Check
-  #   )
+  # the arguments")
   #   # message(strwrap("It seems that you are not using dnorm(mean, sd), \n
   #   # dunif(min, max) or dbeta(a, b) as prior, are you sure?"))
   #
-  # ArgumentCheck::finishArgCheck(Check)
+  # checkmate::reportAssertions(Check)
 
   if (is.null(model))
     return(jagsTwoBaselinesFull(...))

--- a/R/jagsBayesianModel.R
+++ b/R/jagsBayesianModel.R
@@ -46,17 +46,13 @@ jagsBayesianModel <- function (model = NULL, ... ) {
   #   if(!grepl("dbeta", argument[[1]])) flag_dbeta <- TRUE
   # }
   #
-  # Check <- checkmate::makeAssertCollection()
-  #
   # if (flag_dnorm | flag_dunif | flag_dbeta)
-  #   Check$push(
+  #   warning(
   #     "It seems that you are not using dnorm(mean, sd),  dunif(min, max)
   # or dbeta(a, b) as priors, or they are not correctly written. Please check
   # the arguments")
   #   # message(strwrap("It seems that you are not using dnorm(mean, sd), \n
   #   # dunif(min, max) or dbeta(a, b) as prior, are you sure?"))
-  #
-  # checkmate::reportAssertions(Check)
 
   if (is.null(model))
     return(jagsTwoBaselinesFull(...))

--- a/R/jagsOneBaseline.R
+++ b/R/jagsOneBaseline.R
@@ -92,16 +92,10 @@ jagsOneBaseline <- function (muB = NULL,
     count <- count + 1
   }
 
-  Check <- ArgumentCheck::newArgCheck()
-
   if (count > 0)
-    ArgumentCheck::addWarning(
-      msg = "It seems that you are not using dnorm(mean, sd),  dunif(min, max)
+    warning("It seems that you are not using dnorm(mean, sd),  dunif(min, max)
    or dbeta(a, b) as priors, or they are not correctly written. Please check
-   the arguments.",
-      argcheck = Check
-    )
-  ArgumentCheck::finishArgCheck(Check)
+   the arguments.")
 
   # ----------------------------------------------------------------------------
   # JAGS code for fitting Inverse Wishart version of SIBER to a single group

--- a/R/jagsTwoBaselines.R
+++ b/R/jagsTwoBaselines.R
@@ -127,16 +127,12 @@ jagsTwoBaselines <- function (sigmaNc = NULL,
     count <- count + 1
   }
 
-  Check <- ArgumentCheck::newArgCheck()
-
   if (count > 0)
-    ArgumentCheck::addWarning(
+    warning(
       msg = "It seems that you are not using dnorm(mean, sd),  dunif(min, max)
       or dbeta(a, b) as priors, or they are not correctly written. Please check
       the arguments.",
-      argcheck = Check
     )
-  ArgumentCheck::finishArgCheck(Check)
 
   # ----------------------------------------------------------------------------
   # JAGS code for fitting Inverse Wishart version of SIBER to two groups

--- a/R/jagsTwoBaselinesFull.R
+++ b/R/jagsTwoBaselinesFull.R
@@ -137,16 +137,12 @@ jagsTwoBaselinesFull <- function (sigmaNc = NULL,
     count <- count + 1
   }
 
-  Check <- ArgumentCheck::newArgCheck()
-
   if (count > 0)
-    ArgumentCheck::addWarning(
+    warning(
       msg = "It seems that you are not using dnorm(mean, sd),  dunif(min, max)
    or dbeta(a, b) as priors, or they are not correctly written. Please check
-   the arguments.",
-      argcheck = Check
+   the arguments."
     )
-  ArgumentCheck::finishArgCheck(Check)
 
   # ----------------------------------------------------------------------------
   # JAGS code for fitting Inverse Wishart version of SIBER to two groups


### PR DESCRIPTION
I saw your package show up as a reverse dependency to `ArgumentCheck`. Unfortunately, I have abandoned maintaining `ArgumentCheck` and adopted the use of `checkmate` instead. I plan to eventually remove `ArgumentCheck` from CRAN.

I removed the use of `ArgumentCheck` in this pull request.  It wasn't truly necessary, as you only perform one check, and it returns a warning.  (The premise of `ArgumentCheck` is better suited to multiple errors, and `checkmate` handles them better anyway).